### PR TITLE
fix: gestire chunk streaming LiteLLM con delta.text/message.text

### DIFF
--- a/src/aiqo_pg_ai_report/ai_caller.py
+++ b/src/aiqo_pg_ai_report/ai_caller.py
@@ -144,8 +144,14 @@ class AiCaller:
                 text_piece = None
                 if delta is not None:
                     text_piece = self._extract_text_from_content(getattr(delta, "content", None))
+                    if not text_piece:
+                        text_piece = self._extract_text_from_content(getattr(delta, "text", None))
                 if not text_piece and message is not None:
                     text_piece = self._extract_text_from_content(getattr(message, "content", None))
+                    if not text_piece:
+                        text_piece = self._extract_text_from_content(getattr(message, "text", None))
+                if not text_piece:
+                    text_piece = self._extract_text_from_content(getattr(choice, "text", None))
 
                 if text_piece:
                     content_parts.append(text_piece)

--- a/tests/test_ai_caller.py
+++ b/tests/test_ai_caller.py
@@ -223,3 +223,38 @@ def test_call_ai_provider_streaming_objects(monkeypatch):
     assert result == "alpha beta gamma"
     assert caller.total_input_tokens == 4
     assert caller.total_output_tokens == 3
+
+
+def test_call_ai_provider_streaming_delta_text(monkeypatch):
+    monkeypatch.setattr("aiqo_pg_ai_report.ai_caller.litellm.token_counter", lambda **kwargs: 8)
+    monkeypatch.setattr(
+        "aiqo_pg_ai_report.ai_caller.litellm.get_model_info",
+        lambda model: {"max_input_tokens": 100, "litellm_provider": "google"},
+    )
+    monkeypatch.setattr("aiqo_pg_ai_report.ai_caller.litellm.completion_cost", lambda completion_response: 0.0)
+
+    class ChunkChoice:
+        def __init__(self, text):
+            self.delta = types.SimpleNamespace(text=text)
+            self.message = None
+
+    class Chunk:
+        def __init__(self, text, usage=None):
+            self.choices = [ChunkChoice(text)]
+            self.usage = usage
+
+    def fake_completion(**kwargs):
+        return [
+            Chunk(text="prima "),
+            Chunk(text="parte", usage=DummyUsage(2, 5)),
+        ]
+
+    monkeypatch.setattr("aiqo_pg_ai_report.ai_caller.litellm.completion", fake_completion)
+
+    caller = AiCaller(model="gemini-3-flash-preview", ai_call_timeout=5, lang="en", prompts={}, debug=False)
+
+    result = caller.call_ai_provider("prompt text")
+
+    assert result == "prima parte"
+    assert caller.total_input_tokens == 2
+    assert caller.total_output_tokens == 5


### PR DESCRIPTION
### Motivation
- Dopo l'aggiornamento di LiteLLM (>=1.80.5) lo streaming può restituire chunks che espongono il testo in `delta.text` o `message.text` invece del solito `content`, causando report IA vuoti per Gemini e altri modelli.

### Description
- Aggiornato `_handle_streaming_response` in `src/aiqo_pg_ai_report/ai_caller.py` per leggere in ordine `delta.content`, `delta.text`, `message.content`, `message.text` e come ultimo fallback `choice.text`.
- Aggiunto un test di regressione `test_call_ai_provider_streaming_delta_text` in `tests/test_ai_caller.py` che copre i chunk streaming che forniscono solo `delta.text` e verifica l'accumulo di `usage`.

### Testing
- Eseguito `poetry run pytest -k "streaming"`, che non ha potuto completare a causa di un ambiente senza il pacchetto `litellm` (`ModuleNotFoundError: No module named 'litellm'`).
- Il nuovo test è presente e riproduce il caso di regressione, pronto per essere eseguito in un ambiente con `litellm` installato.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b275b70f4832e9a90cd499d4c1eb1)