### PR TITLE
feat: aggiornare modello predefinito a gemini-3.1-flash-lite-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ set GEMINI_API_KEY="your_gemini_api_key_here"
 You can also use a generic `LITELLM_API_KEY` if you are using a provider that `litellm` supports via this generic key. Refer to the [LiteLLM documentation](https://litellm.ai/docs/providers) for specific provider configurations.
 
 **Default Models**:
-The default model is `gemini-2.5-flash`. You can specify a different model using the `--model` CLI argument.
+The default model is `gemini-3.1-flash-lite-preview`. You can specify a different model using the `--model` CLI argument.
 
 ## PostgreSQL Configuration
 
@@ -170,7 +170,7 @@ poetry run python src/aiqo_pg_ai_report/pg_autoexplain_analyzer.py \
 
 *   **`--model <MODEL>`** (`-m`):
     *   Specify the AI model to use for analysis (e.g., `gpt-4o`, `gemini-1.5-pro`, `o1-mini`).
-    *   Default: `gemini-2.5-flash`
+    *   Default: `gemini-3.1-flash-lite-preview`
 
 *   **`--format <FORMAT>`** (`-fmt`):
     *   Specify the log format to parse: `text` (default), `json` (supported), `yaml` (currently unsupported).

--- a/src/aiqo_pg_ai_report/pg_autoexplain_analyzer.py
+++ b/src/aiqo_pg_ai_report/pg_autoexplain_analyzer.py
@@ -22,7 +22,7 @@ from aiqo_pg_ai_report.context import ContextLoader
 from aiqo_pg_ai_report.version import get_package_version, get_litellm_version
 
 DEFAULT_LANG = "fr"  # Default language for output, not for prompt file selection
-DEFAULT_MODEL = "gemini-2.5-flash"
+DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
 DEFAULT_MAX_AI_CALLS_UNLIMITED = -1
 DEFAULT_DUPLICATE_QUERY_AI_SKIP_MESSAGE = "AI analysis skipped, same query was already analyzed earlier."
 


### PR DESCRIPTION
### Motivation
- Aggiornare il valore predefinito del modello usato dalla CLI per utilizzare `gemini-3.1-flash-lite-preview` come nuovo modello raccomandato.

### Description
- Ho modificato la costante `DEFAULT_MODEL` in `src/aiqo_pg_ai_report/pg_autoexplain_analyzer.py` e aggiornato le menzioni corrispondenti in `README.md` per allineare la documentazione alla nuova impostazione.

### Testing
- Eseguito `poetry run pytest`, che ha fallito durante la fase di raccolta a causa di dipendenze mancanti (`litellm`, `sqlparse`) nell'ambiente di esecuzione, quindi non sono stati eseguiti i test unitari.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d8aecd7c832eb56c51de9d15ce85)