### PR TITLE
fix: scroll del pannello dettagli al primo accordion aperto

### DIFF
--- a/src/aiqo_pg_ai_report/report_templates/static/js/components/tabs.js
+++ b/src/aiqo_pg_ai_report/report_templates/static/js/components/tabs.js
@@ -172,7 +172,30 @@
       row.setAttribute('aria-selected', 'true');
       targetPane.classList.add('show', 'active');
 
+      this._scrollDetailPanelToFirstOpenAccordion(targetPane);
+
       row.dispatchEvent(new Event('shown.bs.tab', { bubbles: true }));
+    },
+
+    _scrollDetailPanelToFirstOpenAccordion(targetPane) {
+      if (!targetPane) return;
+
+      const detailPane = targetPane.closest('.split');
+      if (!detailPane) return;
+
+      const firstOpenAccordion = targetPane.querySelector('.accordion-collapse.show');
+      if (!firstOpenAccordion) return;
+
+      window.requestAnimationFrame(() => {
+        const detailPaneRect = detailPane.getBoundingClientRect();
+        const accordionRect = firstOpenAccordion.getBoundingClientRect();
+        const targetScrollTop = detailPane.scrollTop + (accordionRect.top - detailPaneRect.top) - 8;
+
+        detailPane.scrollTo({
+          top: Math.max(0, targetScrollTop),
+          behavior: 'smooth',
+        });
+      });
     },
 
     _renderQueryGantts() {


### PR DESCRIPTION
### Motivation
- Migliorare l’esperienza utente facendo sì che, quando si seleziona una query dal pannello sinistro, il pannello di dettaglio a destra scrolli automaticamente fino al primo accordion già aperto.

### Description
- Aggiunta chiamata a `_scrollDetailPanelToFirstOpenAccordion(targetPane)` in `_activateQueryRow` e implementata la funzione `_scrollDetailPanelToFirstOpenAccordion` che individua il primo `.accordion-collapse.show`, calcola l’offset relativo e effettua `scrollTo(..., behavior: 'smooth')` con controlli di sicurezza; file modificato: `src/aiqo_pg_ai_report/report_templates/static/js/components/tabs.js`.

### Testing
- Eseguito il comando `poetry run pytest -q`, che ha fallito in fase di raccolta a causa di dipendenze mancanti (`ModuleNotFoundError: No module named 'litellm'` e `No module named 'sqlparse'`) quindi i test automatizzati non sono stati completati.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3db853458832ea656b038c3920a24)