### PR TITLE
ci: aggiungi cache Nuitka con ccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
             archive_asset: dist/windows/pg_aiqo_report-windows.zip
             label: Windows Binary
     runs-on: ${{ matrix.os }}
+    env:
+      NUITKA_CACHE_DIR: ${{ github.workspace }}/.github-cache/nuitka/${{ matrix.target }}
+      NUITKA_CACHE_DIR_CCACHE: ${{ github.workspace }}/.github-cache/nuitka/${{ matrix.target }}/ccache
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -110,6 +113,26 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install ccache (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache
+
+      - name: Install ccache (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ccache
+
+      - name: Restore Nuitka build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.NUITKA_CACHE_DIR }}
+          key: nuitka-${{ runner.os }}-${{ matrix.target }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'scripts/build_nuitka.sh', '.github/workflows/ci.yml') }}
+          restore-keys: |
+            nuitka-${{ runner.os }}-${{ matrix.target }}-py${{ env.PYTHON_VERSION }}-
+            nuitka-${{ runner.os }}-${{ matrix.target }}-
 
       - name: Install Poetry
         run: pipx install poetry

--- a/README.md
+++ b/README.md
@@ -258,3 +258,5 @@ Build them with:
 poetry install --with dev
 ./scripts/build_nuitka.sh <linux|macos-silicon|windows>
 ```
+
+The GitHub Actions release workflow persists Nuitka caches between runs by restoring `${GITHUB_WORKSPACE}/.github-cache/nuitka/<target>` through `actions/cache`. When `ccache` is available, the build script points Nuitka to that cached compiler store automatically.

--- a/scripts/build_nuitka.sh
+++ b/scripts/build_nuitka.sh
@@ -20,6 +20,17 @@ OUTPUT_BASENAME="pg_aiqo_report"
 TARGET_DIST_DIR="dist/${TARGET_OS}"
 
 export PYTHONPATH="src:${PYTHONPATH:-}"
+export NUITKA_CACHE_DIR="${NUITKA_CACHE_DIR:-${PROJECT_ROOT}/.nuitka-cache}"
+export NUITKA_CACHE_DIR_CCACHE="${NUITKA_CACHE_DIR_CCACHE:-${NUITKA_CACHE_DIR}/ccache}"
+mkdir -p "${NUITKA_CACHE_DIR_CCACHE}"
+
+if command -v ccache >/dev/null 2>&1; then
+  export NUITKA_CCACHE_BINARY="${NUITKA_CCACHE_BINARY:-$(command -v ccache)}"
+  echo "Using ccache from ${NUITKA_CCACHE_BINARY}"
+else
+  echo "ccache not found in PATH; Nuitka will build without compiler cache."
+fi
+
 
 # Precompute version for frozen builds to avoid setuptools_scm at runtime
 export VERSION_FILE="$PROJECT_ROOT/src/aiqo_pg_ai_report/_version_generated.txt"


### PR DESCRIPTION
### Motivation
- Ridurre i tempi di rilascio permettendo il riuso degli artefatti di build di Nuitka tra esecuzioni del workflow GitHub Actions.
- Abilitare un compiler cache locale (`ccache`) per sfruttare la cache dei compilatori quando disponibile.

### Description
- Aggiornato `/.github/workflows/ci.yml` per impostare `NUITKA_CACHE_DIR` e `NUITKA_CACHE_DIR_CCACHE`, installare `ccache` su Linux/macOS e ripristinare la cache con `actions/cache@v4` usando una chiave che include OS, target, versione Python e file rilevanti.
- Modificato `scripts/build_nuitka.sh` per introdurre `NUITKA_CACHE_DIR` e `NUITKA_CACHE_DIR_CCACHE`, creare la directory di cache, rilevare `ccache` nel `PATH` ed esportare `NUITKA_CCACHE_BINARY` come fallback.
- Aggiornato `README.md` per documentare il comportamento della cache e la posizione `${GITHUB_WORKSPACE}/.github-cache/nuitka/<target>` usata dal workflow.

### Testing
- Eseguito `git diff --check` e risultato: successo (nessun errore di diff/whitespace).
- Eseguito `bash -n scripts/build_nuitka.sh` (syntax check) e risultato: successo (nessun errore di sintassi).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb2fda09c832eae12293b4155d361)