### PR TITLE
fix: rendi 'Daily trends' primo pannello Summary e attivo di default

### DIFF
--- a/src/aiqo_pg_ai_report/report_templates/components/_global_synthesis.html
+++ b/src/aiqo_pg_ai_report/report_templates/components/_global_synthesis.html
@@ -1,5 +1,36 @@
 {% from '_macros.html' import chart_container %}
 
+<div id="summary-panel-trends" class="aiqo-section-panel aiqo-overview-scroll">
+    <h2 class="aiqo-section-panel-title">Daily cumulative time and query volume trends</h2>
+    <div class="mb-3">
+        <div class="d-flex flex-wrap align-items-center gap-3 mb-2 small">
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="toggle-global-server" checked>
+                <label class="form-check-label" for="toggle-global-server">Server Optimizations</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="toggle-global-events">
+                <label class="form-check-label" for="toggle-global-events">Events</label>
+            </div>
+        </div>
+        {{ chart_container('dailyCumulatedTimeChart') }}
+    </div>
+    <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <div class="card card-body h-100" id="legend-server-card">
+                <h6 class="fw-bold mb-2">Server Optimizations</h6>
+                <div id="genericOptimizationLegendServer" class="small"></div>
+            </div>
+        </div>
+        <div class="col-12 col-md-6">
+            <div class="card card-body h-100" id="legend-events-card">
+                <h6 class="fw-bold mb-2">Events</h6>
+                <div id="genericOptimizationLegendEvents" class="small"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div id="summary-panel-expensive-queries" class="aiqo-section-panel aiqo-overview-scroll">
     <h2 class="aiqo-section-panel-title">Most expensive queries (all periods)</h2>
     <div class="card card-body">
@@ -32,37 +63,6 @@
     <div class="alert alert-info mb-0">{{ ai.general_hints_synthesis | safe }}</div>
 </div>
 {% endif %}
-
-<div id="summary-panel-trends" class="aiqo-section-panel aiqo-overview-scroll">
-    <h2 class="aiqo-section-panel-title">Daily cumulative time and query volume trends</h2>
-    <div class="mb-3">
-        <div class="d-flex flex-wrap align-items-center gap-3 mb-2 small">
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="toggle-global-server" checked>
-                <label class="form-check-label" for="toggle-global-server">Server Optimizations</label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="toggle-global-events">
-                <label class="form-check-label" for="toggle-global-events">Events</label>
-            </div>
-        </div>
-        {{ chart_container('dailyCumulatedTimeChart') }}
-    </div>
-    <div class="row g-3">
-        <div class="col-12 col-md-6">
-            <div class="card card-body h-100" id="legend-server-card">
-                <h6 class="fw-bold mb-2">Server Optimizations</h6>
-                <div id="genericOptimizationLegendServer" class="small"></div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6">
-            <div class="card card-body h-100" id="legend-events-card">
-                <h6 class="fw-bold mb-2">Events</h6>
-                <div id="genericOptimizationLegendEvents" class="small"></div>
-            </div>
-        </div>
-    </div>
-</div>
 
 <script>
 {% include 'static/js/components/global-synthesis.js' %}

--- a/src/aiqo_pg_ai_report/report_templates/components/_sidebar.html
+++ b/src/aiqo_pg_ai_report/report_templates/components/_sidebar.html
@@ -117,6 +117,10 @@
     {# ── Summary section: nav items ──────────────────────────────────────────── #}
     <div id="aiqo-sidebar-section-summary" class="aiqo-sidebar-section">
         <nav class="aiqo-section-nav" aria-label="Summary navigation">
+            <button class="aiqo-section-nav-btn" type="button" data-panel="summary-panel-trends">
+                <i class="bi bi-graph-up" aria-hidden="true"></i>
+                <span>Daily trends</span>
+            </button>
             <button class="aiqo-section-nav-btn" type="button" data-panel="summary-panel-expensive-queries">
                 <i class="bi bi-table" aria-hidden="true"></i>
                 <span>Most expensive queries</span>
@@ -127,10 +131,6 @@
                 <span>Recurring AI hints</span>
             </button>
             {% endif %}
-            <button class="aiqo-section-nav-btn" type="button" data-panel="summary-panel-trends">
-                <i class="bi bi-graph-up" aria-hidden="true"></i>
-                <span>Daily trends</span>
-            </button>
         </nav>
     </div>{# /summary section #}
 


### PR DESCRIPTION
### Motivation
- Garantire che la sezione "Summary / Daily Trends" sia mostrata come prima voce e selezionata di default sfruttando il comportamento esistente che attiva il primo pannello della Summary.

### Description
- Spostato il markup del pannello `summary-panel-trends` prima degli altri pannelli Summary in `src/aiqo_pg_ai_report/report_templates/components/_global_synthesis.html`.
- Riordinata la lista di navigazione Summary inserendo il pulsante `data-panel="summary-panel-trends"` come primo elemento in `src/aiqo_pg_ai_report/report_templates/components/_sidebar.html`.
- Nessuna modifica al codice JavaScript di attivazione è stata necessaria poiché l'inizializzazione chiama già `this._activateFirstPanel('summary')`, che ora selezionerà la voce `Daily trends` come prima scelta.

### Testing
- Eseguito uno script Python che verifica che `data-panel="summary-panel-trends"` compaia prima di `summary-panel-expensive-queries` in `src/aiqo_pg_ai_report/report_templates/components/_sidebar.html` e che `id="summary-panel-trends"` sia posizionato prima di `summary-panel-expensive-queries` in `src/aiqo_pg_ai_report/report_templates/components/_global_synthesis.html`.
- Tentativo di eseguire l'intera suite con `poetry run pytest -q` fallito durante la raccolta a causa di dipendenze mancanti nell'ambiente di esecuzione (`litellm`, `jinja2`, `sqlparse`), quindi i test automatici completi non sono stati eseguiti.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3289cf67f4832ea27e848e2cc85fbe)